### PR TITLE
Update class-controller-forms.php

### DIFF
--- a/includes/controllers/class-controller-forms.php
+++ b/includes/controllers/class-controller-forms.php
@@ -378,7 +378,7 @@ class GF_REST_Forms_Controller extends GF_REST_Controller {
 				return new WP_Error( 'missing_form', __( 'The Form object must be sent as a JSON string in the request body with the content-type header set to application/json.', 'gravityforms' ) );
 			}
 		}
-		$form = json_decode( $form_json, true );
+		$form = (is_string($form_json)) ? json_decode( $form_json, true ) : $form_json;
 
 		$form = GFFormsModel::convert_field_objects( $form );
 


### PR DESCRIPTION
The existing code assumes that $form_json is a string, when it is actually a JSON object. The WP_REST_Request object returns the parameters as a JSON-formatted body when calling get_json_params. We added a "just-in-case" check for a string version of the JSON structure.