### PR TITLE
Catch error when submitting to inactive, non-existent form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 tmp
+.DS_Store
+.idea/

--- a/includes/controllers/class-controller-form-submissions.php
+++ b/includes/controllers/class-controller-form-submissions.php
@@ -62,6 +62,10 @@ class GF_REST_Form_Submissions_Controller extends GF_REST_Controller {
 
 		$result = GFAPI::submit_form( $form_id, $input_values, $field_values, $target_page, $source_page );
 
+		if ( is_wp_error( $result ) ) {
+			return new WP_Error( $result->get_error_code(), $result->get_error_message(), array( 'status' => 400 ) );
+		}
+
 		$response = $this->prepare_item_for_response( $result, $request );
 
 		if ( isset( $result['confirmation_type'] ) && $result['confirmation_type'] == 'redirect' ) {

--- a/tests/unit-tests/test-form-submissions.php
+++ b/tests/unit-tests/test-form-submissions.php
@@ -92,6 +92,31 @@ class Tests_GF_REST_API_Form_Submissions extends GF_UnitTestCase {
 		$this->assertEquals( 1, $count );
 	}
 
+	function test_invalid_form() {
+
+		$request = new WP_REST_Request( 'POST', $this->namespace . '/forms/999/submissions' );
+
+		$body = array(
+			'input_1' => 'First Choice',
+			'input_2_2' => 'Second Choice',
+			'input_5' => 'Testing the submissions endpoint',
+			'input_8' => '9',
+			'input_11' => '11:10',
+			'field_values' => '',
+			'target_page'  => 0,
+			'source_page'  => 1,
+		);
+
+		// Both $request and $_POST need the input values to simulate the request.
+		$request->set_body_params( $body );
+		$_POST = $body;
+
+		$response = $this->server->dispatch( $request );
+		$status = $response->get_status();
+		$this->assertEquals( 400, $status );
+
+	}
+
 	function test_redirect_confirmation() {
 
 		if ( version_compare( GFForms::$version, '2.3-dev-1', '<' ) ) {


### PR DESCRIPTION
This PR catches errors thrown by `GFAPI::submit_form()` when submitting a form. Addresses issue #14.